### PR TITLE
important: add [category] layer to par: par[category].rpars

### DIFF
--- a/processing_funcs/process_ctc.jl
+++ b/processing_funcs/process_ctc.jl
@@ -22,8 +22,8 @@ function process_ctc(data::LegendData, period::DataPeriod, run::DataRun, categor
    energy_types::Vector{Symbol} = Symbol.(ctc_config.energy_types), juleana_logo::Bool = false, reprocess::Bool = false)
 
     @debug "Create pars db"
-    mkpath(joinpath(data_path(data.par.rpars.ctc), string(period)))
-    pars_db = PropDict(data.par.rpars.ctc[period, run])
+    mkpath(joinpath(data_path(data.par[category].rpars.ctc), string(period)))
+    pars_db = PropDict(data.par[category].rpars.ctc[period, run])
     pars_db = ifelse(reprocess, PropDict(), pars_db)
     if reprocess @info "Start reprocessing" end
 
@@ -144,8 +144,8 @@ function process_ctc(data::LegendData, period::DataPeriod, run::DataRun, categor
 
     # save results to pars 
     result_ctc = PropDict(Dict("$channel" => result_dict))
-    writelprops(data.par.rpars.ctc[period], run, result_ctc)
-    writevalidity(data.par.rpars.ctc, filekey, (period, run))
+    writelprops(data.par[category].rpars.ctc[period], run, result_ctc)
+    writevalidity(data.par[category].rpars.ctc, filekey, (period, run))
     @info "Saved pars to disk"
     return (result = result_ctc, status = processed_dict)
 end 

--- a/processing_funcs/process_decaytime.jl
+++ b/processing_funcs/process_decaytime.jl
@@ -9,7 +9,7 @@ function process_decaytime(data::LegendData, period::DataPeriod, run::DataRun, c
         return
     end
 
-    det = _channel2detector(data, channel)
+    det_ged = _channel2detector(data, channel)
     @debug "Create pars db"
     mkpath(joinpath(data_path(data.par.rpars.pz), string(period)))
     
@@ -36,9 +36,9 @@ function process_decaytime(data::LegendData, period::DataPeriod, run::DataRun, c
     end
     savelfig(LegendMakie.lsavefig, fig, data, filekey, channel, :decay_time)
 
-    @info "Found decay time at $(round(u"µs", result.µ, digits=2)) for channel $channel / det $det"
+    @info "Found decay time at $(round(u"µs", result.µ, digits=2)) for channel $channel / det $det_ged"
     result_pz = (τ = result.μ, fit = result)
-    writelprops(data.par.rpars.pz[period], run, PropDict("$channel" => result_pz))
+    writelprops(data.par[category].rpars.pz[period], run, PropDict("$channel" => result_pz))
     @info "Saved pars to disk"
     display(fig)
     return fig

--- a/processing_funcs/process_dsp.jl
+++ b/processing_funcs/process_dsp.jl
@@ -76,7 +76,7 @@ function process_dsp(data::LegendData, period::DataPeriod, run::DataRun, categor
     @info "use default DSP config and filter parameter "
     filekeys = search_disk(FileKey, data.tier[DataTier(:raw), category , period, run])
     dsp_config = DSPConfig(dataprod_config(data).dsp(filekeys[1]).default)
-    τ_pz = mvalue(get_values(data.par.rpars.pz[period, run, channel]).τ)
-    pars_filter = data.par.rpars.fltopt[period,run,channel]
+    τ_pz = mvalue(get_values(data.par[category].rpars.pz[period, run, channel]).τ)
+    pars_filter = data.par[category].rpars.fltopt[period,run,channel]
     process_dsp(data, period, run, category, channel, dsp_config, τ_pz, pars_filter; kwargs...)
 end 

--- a/processing_funcs/process_filteropt.jl
+++ b/processing_funcs/process_filteropt.jl
@@ -28,14 +28,14 @@ function process_filteropt(data::LegendData, period::DataPeriod, run::DataRun, c
     @info "Optimize filter for period $period, run $run, channel $channel /det $det - $filter_types"
 
     # check if decaytime pars already exist
-    fltopt_file = joinpath(mkpath(data_path(data.par.rpars.fltopt[period])), "$(string(run)).json")
+    fltopt_file = joinpath(mkpath(data_path(data.par[category].rpars.fltopt[period])), "$(string(run)).json")
     if isfile(fltopt_file) && !reprocess
         @info "Filter optimization file already exist for $category period $period - run $run - channel $channel - you're done!"
         return
     end
 
     # prepare results dict
-    mkpath(joinpath(data_path(data.par.rpars.fltopt), string(period)))
+    mkpath(joinpath(data_path(data.par[category].rpars.fltopt), string(period)))
     result_filteropt_dict = Dict{Symbol, NamedTuple}()
     @debug "Created path for filter optimization results"
 
@@ -122,7 +122,7 @@ function process_filteropt(data::LegendData, period::DataPeriod, run::DataRun, c
         result_filteropt_dict[filter_type] =  process_filteropt_fltr(filter_type)
     end
     result = PropDict(Dict("$channel" => result_filteropt_dict))
-    writelprops(data.par.rpars.fltopt[period], run, result)
+    writelprops(data.par[category].rpars.fltopt[period], run, result)
     @info "Saved pars to disk"
 end
 
@@ -133,7 +133,7 @@ function process_filteropt(data::LegendData, period::DataPeriod, run::DataRun, c
     pz_config = dataprod_config(data).dsp(filekeys[1]).pz.default
 
     peak =  Symbol(pz_config.peak)
-    τ_pz = mvalue(get_values(data.par.rpars.pz[period, run, channel]).τ)
+    τ_pz = mvalue(get_values(data.par[category].rpars.pz[period, run, channel]).τ)
     @debug "Loaded decay time for pole-zero correction: $τ_pz"
 
     process_filteropt(data, period, run, category, channel, dsp_config, τ_pz, peak; kwargs...) 

--- a/processing_funcs/process_hit.jl
+++ b/processing_funcs/process_hit.jl
@@ -27,7 +27,7 @@ function process_hit(data::LegendData, period::DataPeriod, run::DataRun, categor
     end 
 
     # load energy calibration
-    ecal_pd = data.par.rpars.ecal[period, run, channel]
+    ecal_pd = data.par[category].rpars.ecal[period, run, channel]
 
     for f in eachindex(filekeys)
         filekey = filekeys[f]

--- a/processing_funcs/process_peakfits.jl
+++ b/processing_funcs/process_peakfits.jl
@@ -6,7 +6,7 @@ function process_peakfits(data::LegendData, period::DataPeriod, run::DataRun, ca
     reprocess::Bool = true, juleana_logo::Bool = false)
     e_type = :e_trap; 
 
-    if !reprocess && haskey(data.par.rpars.ecal[period, run, channel], e_type)
+    if !reprocess && haskey(data.par[category].rpars.ecal[period, run, channel], e_type)
         @info "Energy calibration already exists for all $(e_types)  -> you're done!"
         return
     end
@@ -50,6 +50,6 @@ function process_peakfits(data::LegendData, period::DataPeriod, run::DataRun, ca
     @info "Save peak fit plot to $pname_pulser"  
 
     result_ecal = (µ = result.μ, µ_pulser = result_pulser.μ, fit = result, fit_pulser = result_pulser)
-    writelprops(data.par.rpars.ecal[period], run, PropDict("$channel" => result_ecal))
+    writelprops(data.par[category].rpars.ecal[period], run, PropDict("$channel" => result_ecal))
     @info "Saved pars to disk"
 end

--- a/processing_funcs/process_qualitycuts.jl
+++ b/processing_funcs/process_qualitycuts.jl
@@ -14,7 +14,7 @@ function process_qualitycuts(data::LegendData, period::DataPeriod, run::DataRun,
                             reprocess::Bool = false, qc_config::PropDict = data.metadata.config.qc.qc_config.default)
 
     # check if quality cut pars already exist
-    qc_file = joinpath(mkpath(data_path(data.par.rpars.qc[period])), "$(string(run)).json")
+    qc_file = joinpath(mkpath(data_path(data.par[category].rpars.qc[period])), "$(string(run)).json")
      if isfile(qc_file) && !reprocess
          @info "Quality cuts (qc) file already exist for $category period $period - run $run - channel $channel - you're done!"
          return
@@ -32,7 +32,7 @@ function process_qualitycuts(data::LegendData, period::DataPeriod, run::DataRun,
 
     # save results to pars 
     result_qc = PropDict(Dict("$channel" => qc))
-    writelprops(data.par.rpars.qc[period], run, result_qc)
+    writelprops(data.par[category].rpars.qc[period], run, result_qc)
     @info "Saved pars to disk"
 
     # add qcflag to dsp tier. 


### PR DESCRIPTION
Before, there was no distinction between :cal and :bch pars! That means some pars with the same (period, run, channel), but from different categories were overwritten by the newest version. 

Now par can be accessed with specifying the category:  `data.par[category].rpars.pz[period, run, channel].τ`