### PR TITLE
process_noisesweep and enc_noisesweep function

### DIFF
--- a/processing_funcs/process_noisesweep.jl
+++ b/processing_funcs/process_noisesweep.jl
@@ -1,0 +1,101 @@
+"""
+    process_noisesweep(data::LegendData, period::DataPeriod, run::DataRun, category::Union{Symbol, DataCategory}, channel::ChannelId, dsp_config::DSPConfig, peak::Symbol;reprocess::Bool = true, filter_types::Vector{Symbol} = [:trap, cusp])
+Noise sweep for filter_types
+- load waveforms, shift baseline
+- optimize rise-time for minimum baseline noise after filtering
+- save results to disk
+- sanity plots for noise noise_sweep_
+Inputs: 
+- `data::LegendData`: LegendData object
+- `period::DataPeriod`: data period
+- `run::DataRun`: data run
+- `category::Union{Symbol, DataCategory}`: data category, e.g. :cal
+- `channel::ChannelId`: channel id
+Optional:
+- `dsp_config::DSPConfig`: DSP configuration object. If not specified will take default from metadata
+- `peak::Symbol`: peak to optimize for (needs existing peakfile!). If not specified will take default from metadata
+- `reprocess::Bool`: reprocess the files or not
+- `filter_types::Vector{Symbol}`: filter types to optimize for
+"""
+
+function process_noisesweep(data::LegendData, period::DataPeriod, run::DataRun, category::Union{Symbol, DataCategory}, channel::ChannelId, dsp_config::DSPConfig, peak::Symbol; 
+                reprocess::Bool = false, filter_types::Vector{Symbol} = [:trap, :cusp, :zac])  
+    det = _channel2detector(data, channel)
+    @info "Noise sweep for period $period, run $run, channel $channel /det $det - $filter_types"
+
+    # check if decaytime pars already exist
+    noisesweep_file = joinpath(mkpath(data_path(data.par.rpars.noisesweep[period])), "$(string(run)).json")
+    if isfile(noisesweep_file) && !reprocess
+        @info "Noise sweep file already exist for $category period $period - run $run - channel $channel - you're done!"
+        return
+    end
+
+    # prepare results dict
+    mkpath(joinpath(data_path(data.par.rpars.noisesweep),string(period)))
+    result_noisesweep_dict = Dict{Symbol, NamedTuple}()
+    @debug "Created path for noisesweep results"
+
+    # load waveforms from peak
+    filekeys = search_disk(FileKey, data.tier[DataTier(:raw), category , period, run])
+    if peak == :all 
+        data_peak = read_ldata(data, DataTier(:raw), filekeys, channel)
+        #data_peak = merge(data_peak, (gamma_line = [1170*u"keV"],))
+    else
+        data_peak  = read_ldata((peak), data, :jlpeaks, category, period, run, channel)
+    end 
+    wvfs = data_peak.waveform
+    @debug "Loaded waveforms for peak $peak"
+
+    function process_noisesweep_fltr(filter_type::Symbol)
+        @info "Noise sweep for filter $filter_type"
+        _, def_ft = get_fltpars(PropDict(), filter_type, dsp_config)
+        filekey = search_disk(FileKey, data.tier[DataTier(:raw), category , period, run])[1]
+        plt_folder = LegendDataManagement.LDMUtils.get_pltfolder(data, filekey, :noisesweep) * "/"
+        if !isdir(plt_folder)
+            mkdir(plt_folder)
+        end
+        # STEP 1: rise-time optimization --> min. baseline noise after filtering 
+        result_rt, report_rt = enc_noisesweep(filter_type, wvfs, dsp_config; ft = def_ft)
+        
+        # Plots_theme()
+        rt_inter = range(ustrip.(report_rt.enc_grid_rt[1]), stop = ustrip(maximum(report_rt.enc_grid_rt[findall(isfinite.(report_rt.enc))])), step = 0.05); 
+        p = Figure()
+        ax = Axis(p[1, 1], 
+            xlabel = "Rise time ($(unit(report_rt.rt)))", ylabel = "Noise (a.u.)",
+            limits = ((ustrip.(extrema(report_rt.enc_grid_rt))[1] - 0.2, ustrip.(extrema(report_rt.enc_grid_rt))[2] + 0.2), (nothing, nothing)),
+            title = "Noise sweep ($filter_type), $period-$run-$channel, $peak peak \n" * @sprintf("fixed ft = %.2f %s, optimal rt = %.1f %s", ustrip(def_ft), unit(def_ft), ustrip(report_rt.rt), unit(report_rt.rt)), )
+        lines!(ax, rt_inter, report_rt.f_interp.(rt_inter), color = :deepskyblue2, linewidth = 3, linestyle = :solid, label = "Interpolation")
+        Makie.scatter!(ax, ustrip.(collect(report_rt.enc_grid_rt)), report_rt.enc,  color = :black, label = "Data")
+        axislegend()
+        pname = plt_folder * split(LegendDataManagement.LDMUtils.get_pltfilename(data, filekeys[1], channel, Symbol("noise_sweep_$(filter_type)")),"/")[end]
+        d = LegendDataManagement.LDMUtils.get_pltfolder(data, filekeys[1], Symbol("noise_sweep_$(filter_type)"))
+        ifelse(isempty(readdir(d)), rm(d), nothing )
+
+        save(pname, p)
+        @info "Save sanity plot to $pname"
+
+        # return result for this filter type
+        #merge(result_rt, result_ft)
+    end 
+
+    # filter optimization: rise-time, and flat-top times
+    for filter_type in filter_types
+        result_noisesweep_dict[filter_type] =  process_noisesweep_fltr(filter_type)
+    end
+    result = PropDict(Dict("$channel" => result_noisesweep_dict))
+    writelprops(data.par.rpars.noisesweep[period], run, result)
+    @info "Saved pars to disk"
+end
+
+# function process_filteropt(data::LegendData, period::DataPeriod, run::DataRun, category::Union{Symbol, DataCategory}, channel::ChannelId; kwargs...)
+    
+#     filekeys = search_disk(FileKey, data.tier[DataTier(:raw), category , period, run])
+#     dsp_config = DSPConfig(dataprod_config(data).dsp(filekeys[1]).default)
+#     pz_config = dataprod_config(data).dsp(filekeys[1]).pz.default
+
+#     peak =  Symbol(pz_config.peak)
+#     τ_pz = mvalue(get_values(data.par.rpars.pz[period, run, channel]).τ)
+#     @debug "Loaded decay time for pole-zero correction: $τ_pz"
+
+#     process_filteropt(data, period, run, category, channel, dsp_config, τ_pz, peak; kwargs...) 
+# end

--- a/processing_funcs/process_noisesweep.jl
+++ b/processing_funcs/process_noisesweep.jl
@@ -69,7 +69,7 @@ function process_noisesweep(data::LegendData, period::DataPeriod, run::DataRun, 
         axislegend()
         pname = plt_folder * split(LegendDataManagement.LDMUtils.get_pltfilename(data, filekeys[1], channel, Symbol("noise_sweep_$(filter_type)")),"/")[end]
         d = LegendDataManagement.LDMUtils.get_pltfolder(data, filekeys[1], Symbol("noise_sweep_$(filter_type)"))
-        ifelse(isempty(readdir(d)), rm(d), nothing )
+        ifelse(isempty(readdir(d)), rm(d), NamedTuple())
 
         save(pname, p)
         @info "Save sanity plot to $pname"
@@ -82,7 +82,7 @@ function process_noisesweep(data::LegendData, period::DataPeriod, run::DataRun, 
     for filter_type in filter_types
         result_noisesweep_dict[filter_type] =  process_noisesweep_fltr(filter_type)
     end
-    result = PropDict(Dict("$channel" => result_noisesweep_dict))
+    result = PropDict("$channel" => result_noisesweep_dict)
     writelprops(data.par.rpars.noisesweep[period], run, result)
     @info "Saved pars to disk"
 end

--- a/src/enc_noisesweep.jl
+++ b/src/enc_noisesweep.jl
@@ -3,35 +3,14 @@ function rms(x::Vector{T}) where {T <: Real}
 end
 
 """
-    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, ft::Quantity{T}, grid_rt::StepRangeLen{Quantity{<:Float64}}, bl_window::ClosedInterval{<:Unitful.Time{T}}, flt_length_cusp::Quantity{T}; cusp_scale::T = 3750.0, τ_cusp::Quantity{<:AbstractFloat} = 10000000.0u"µs") where T<:Real
-    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, ft::Quantity{T}, grid_rt::StepRangeLen{Quantity{<:Float64}}, bl_window::ClosedInterval{<:Unitful.Time{T}}; kwargs...) where T<:Real
-    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, dsp_config::DSPConfig; kwargs...) where T<:Real
-
-DSP filter optimization to find best rise-time (for a given flat-top time) to minimize ENC noise. This is an alternative way to calculate the enc noise compared to `dsp_trap_rt_optimization`.
-Strategy: 
-- Shift waveforms to have a common baseline, and deconvolute them with the pole-zero correction
-- Filter waveforms with given rise-time and flat-top time
-- Build histogram out of all samples in baseline from all waveforms. Remove bins at the beginning and end of the waveform to avoid edge effects.
-- Calculate the RMS of the baseline noise --> ENC noise
-
-Inputs:
-- `filter_type::Symbol`: filter type (:trap or :cusp)
-- `wvfs::ArrayOfRDWaveforms`: raw waveforms to be filtered
-- `τ_pz::Quantity{T}`: pole-zero decay time 
-- `ft::Quantity{T}`: fixed flat-top time for optimization
-- `grid_rt::StepRangeLen{Quantity{<:Float64}}`: grid of rise-times to scan
-- `bl_window::ClosedInterval{<:Unitful.Time{T}}`: baseline window to calculate noise
-- `flt_length_cusp::Quantity{T}`: flat-top length; only relevant for cusp filter
-- `cusp_scale::T`: scale factor for cusp filter; only relevant for cusp filter
-- `τ_cusp::Quantity{<:AbstractFloat}`: cusp decay time; only relevant for cusp filter
-Alternatively, a `dsp_config` can be given as input instead of `ft`, `grid_rt`, `bl_window`, `flt_length_cusp`.
-- `dsp_config::DSPConfig`: DSP configuration object
 """
 function enc_noisesweep(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, dsp_config::DSPConfig; 
              ft::Quantity{T}= 0.0u"µs", τ_cusp::Quantity{<:AbstractFloat} = 10000000.0u"µs", τ_zac::Quantity{<:AbstractFloat} = 10000000.0u"µs" ) where T<:Real
 
     # gather config parameters 
     grid_rt   = getproperty(dsp_config, Symbol("e_grid_rt_$(filter_type)"))
+    cap = getproperty(energy_config, Symbol("C_Pulser"))
+    temp = getproperty(energy_config, Symbol("Temp"))
     if ft == 0.0u"µs"
         (_, ft) = get_fltpars(PropDict(), :trap, dsp_config)
     end
@@ -48,10 +27,10 @@ function enc_noisesweep(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, dsp_confi
     # waveforms: shift baseline and deconvolute (pole-zero)
     bl_stats = signalstats.(wvfs, leftendpoint(bl_window), rightendpoint(bl_window))
     wvfs_shift = shift_waveform.(wvfs, -bl_stats.mean)
-
-    # STEP 1: rise-time optimization 
+ 
     # calculate baseline rms after filtering 
     # filtered waveforms are already truncated to valid windows. no additional truncation needed.
+    noise_au = zeros(length(grid_rt))
     noise = zeros(length(grid_rt))
     for (i, rt) in enumerate(collect(grid_rt))
         if filter_type == :trap
@@ -63,7 +42,8 @@ function enc_noisesweep(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, dsp_confi
         end
         valid_bins = findall(leftendpoint(bl_window) .<=  wvfs_flt[1].time .<=rightendpoint(bl_window)) # bins within baseline of filtered waveform 
         bl_trap = filter.(isfinite, map(x-> x.signal[valid_bins], wvfs_flt)) # baselines - cut bins in beginning and end 
-        noise[i] = rms(vcat(bl_trap...))
+        noise_au[i] = rms(vcat(bl_trap...))
+        noise[i] = pulser_ADC_to_keV(noise_au[i],cap,temp)
     end
 
     # find optimal shaping time: 

--- a/src/enc_noisesweep.jl
+++ b/src/enc_noisesweep.jl
@@ -1,0 +1,86 @@
+function rms(x::Vector{T}) where {T <: Real} 
+    sqrt(mean(x.^2))
+end
+
+"""
+    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, ft::Quantity{T}, grid_rt::StepRangeLen{Quantity{<:Float64}}, bl_window::ClosedInterval{<:Unitful.Time{T}}, flt_length_cusp::Quantity{T}; cusp_scale::T = 3750.0, τ_cusp::Quantity{<:AbstractFloat} = 10000000.0u"µs") where T<:Real
+    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, ft::Quantity{T}, grid_rt::StepRangeLen{Quantity{<:Float64}}, bl_window::ClosedInterval{<:Unitful.Time{T}}; kwargs...) where T<:Real
+    filteropt_rt_optimization_blnoise(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, τ_pz::Quantity{T}, dsp_config::DSPConfig; kwargs...) where T<:Real
+
+DSP filter optimization to find best rise-time (for a given flat-top time) to minimize ENC noise. This is an alternative way to calculate the enc noise compared to `dsp_trap_rt_optimization`.
+Strategy: 
+- Shift waveforms to have a common baseline, and deconvolute them with the pole-zero correction
+- Filter waveforms with given rise-time and flat-top time
+- Build histogram out of all samples in baseline from all waveforms. Remove bins at the beginning and end of the waveform to avoid edge effects.
+- Calculate the RMS of the baseline noise --> ENC noise
+
+Inputs:
+- `filter_type::Symbol`: filter type (:trap or :cusp)
+- `wvfs::ArrayOfRDWaveforms`: raw waveforms to be filtered
+- `τ_pz::Quantity{T}`: pole-zero decay time 
+- `ft::Quantity{T}`: fixed flat-top time for optimization
+- `grid_rt::StepRangeLen{Quantity{<:Float64}}`: grid of rise-times to scan
+- `bl_window::ClosedInterval{<:Unitful.Time{T}}`: baseline window to calculate noise
+- `flt_length_cusp::Quantity{T}`: flat-top length; only relevant for cusp filter
+- `cusp_scale::T`: scale factor for cusp filter; only relevant for cusp filter
+- `τ_cusp::Quantity{<:AbstractFloat}`: cusp decay time; only relevant for cusp filter
+Alternatively, a `dsp_config` can be given as input instead of `ft`, `grid_rt`, `bl_window`, `flt_length_cusp`.
+- `dsp_config::DSPConfig`: DSP configuration object
+"""
+function enc_noisesweep(filter_type::Symbol, wvfs::ArrayOfRDWaveforms, dsp_config::DSPConfig; 
+             ft::Quantity{T}= 0.0u"µs", τ_cusp::Quantity{<:AbstractFloat} = 10000000.0u"µs", τ_zac::Quantity{<:AbstractFloat} = 10000000.0u"µs" ) where T<:Real
+
+    # gather config parameters 
+    grid_rt   = getproperty(dsp_config, Symbol("e_grid_rt_$(filter_type)"))
+    if ft == 0.0u"µs"
+        (_, ft) = get_fltpars(PropDict(), :trap, dsp_config)
+    end
+    bl_window = dsp_config.bl_window
+
+    # cusp-specific filter parameters 
+    flt_length_cusp = getproperty(dsp_config, Symbol("flt_length_cusp"))
+    cusp_scale = ustrip(NoUnits, flt_length_cusp/step(wvfs[1].time))
+
+    # zac-specific filter parameters 
+    flt_length_zac = getproperty(dsp_config, Symbol("flt_length_zac"))
+    zac_scale = ustrip(NoUnits, flt_length_zac/step(wvfs[1].time))
+
+    # waveforms: shift baseline and deconvolute (pole-zero)
+    bl_stats = signalstats.(wvfs, leftendpoint(bl_window), rightendpoint(bl_window))
+    wvfs_shift = shift_waveform.(wvfs, -bl_stats.mean)
+
+    # STEP 1: rise-time optimization 
+    # calculate baseline rms after filtering 
+    # filtered waveforms are already truncated to valid windows. no additional truncation needed.
+    noise = zeros(length(grid_rt))
+    for (i, rt) in enumerate(collect(grid_rt))
+        if filter_type == :trap
+            wvfs_flt =  TrapezoidalChargeFilter(rt, ft).(wvfs_shift)   # filtered waveforms 
+        elseif filter_type == :cusp
+            wvfs_flt = CUSPChargeFilter(rt, ft, τ_cusp, flt_length_cusp, cusp_scale).(wvfs_shift) 
+        elseif filter_type == :zac
+            wvfs_flt = ZACChargeFilter(rt, ft, τ_zac, flt_length_zac, zac_scale).(wvfs_shift)
+        end
+        valid_bins = findall(leftendpoint(bl_window) .<=  wvfs_flt[1].time .<=rightendpoint(bl_window)) # bins within baseline of filtered waveform 
+        bl_trap = filter.(isfinite, map(x-> x.signal[valid_bins], wvfs_flt)) # baselines - cut bins in beginning and end 
+        noise[i] = rms(vcat(bl_trap...))
+    end
+
+    # find optimal shaping time: 
+    if  all(.!isfinite.(noise))
+        @error "Error: no finite noise values found for filter type $filter_type - try adjusting grid_rt."
+    end
+    result, report = let enc = noise[findall(isfinite.(noise))], rt = ustrip.(collect(grid_rt))[findall(isfinite.(noise))]
+        if length(enc) >= 4
+            f_interp = BSplineKit.interpolate(rt, enc, BSplineOrder(4))
+        else
+            f_interp = LinearInterpolation(rt, enc)
+        end
+        result = optimize(f_interp, minimum(rt), maximum(rt)) 
+        rt_opt = Optim.minimizer(result)*u"µs" # optimial rise time for trap filter
+        min_enc = Optim.minimum(result)
+        (rt = rt_opt, min_enc = min_enc), (rt = rt_opt, min_enc = min_enc, enc_grid_rt = grid_rt, enc = noise, f_interp = f_interp)
+    end
+    return result, report 
+end
+

--- a/utils/utils_physics.jl
+++ b/utils/utils_physics.jl
@@ -41,7 +41,7 @@ function pulser_ADC_to_electrons(ADC::Real, C_pulser::Real; bits::Int = 14,  dyn
     return  (V/gain * C_pulser) / electron_charge  # charge in electrons
 end
 
-function pulser_ADC_to_keV(ADC::Real, C_pulser::Real; bits::Int = 14,  dynamicrange_V::Real = 2.0, gain::Real = 1.0)
-    return  pulser_ADC_to_electrons(ADC, C_pulser; bits = bits, dynamicrange_V = dynamicrange_V, gain = gain) * Ge_Energy_per_eholePair(90) / 1e3
+function pulser_ADC_to_keV(ADC::Real, C_pulser::Real,T::Real; bits::Int = 14,  dynamicrange_V::Real = 2.0, gain::Real = 1.0)
+    return  pulser_ADC_to_electrons(ADC, C_pulser; bits = bits, dynamicrange_V = dynamicrange_V, gain = gain) * Ge_Energy_per_eholePair(T) / 1e3
 end
 


### PR DESCRIPTION
Added process_noisesweep and enc_noisesweep function.
Tried to implement enc conversion in enc_noisesweep using ecal_config, but not yet add the "ecal_config" argument to the processors.
If you want to convert after processing separately, please delete lines related to c_pulser and temp.

util_physics.jl
add T::Real argument